### PR TITLE
Remove 'Athletics' from menu

### DIFF
--- a/menu.php
+++ b/menu.php
@@ -52,9 +52,6 @@ defined('ABSPATH') OR exit;
                                 <button class="toggle-mega-menu" aria-expanded="false" aria-controls="academics-subs">Academics<span class="caret-icon" aria-hidden="true"></span></button>
                             </li>
                             <li>
-                                <a target="_blank" rel="noopener" href="https://highlandcougars.com/">Athletics</a>
-                            </li>
-                            <li>
                             <button class="toggle-mega-menu" aria-expanded="false" aria-controls="campus-subs">Campus &amp; Community<span class="caret-icon" aria-hidden="true"></span></button>
                             </li>
                             <li>


### PR DESCRIPTION
The main menu on multiple pages is hardcoded into the template. This PR removes the 'Althletics' item from that menu (it's submenu was already commented out).