### PR TITLE
added: set aria-hidden attribute for separator elements

### DIFF
--- a/includes/js/custom.js
+++ b/includes/js/custom.js
@@ -384,3 +384,9 @@ document.addEventListener('DOMContentLoaded', function() {
         figure.parentNode.replaceChild(ul, figure);
     }
 });
+
+document.addEventListener("DOMContentLoaded", function() {
+    document.querySelectorAll("hr.separator-aria-hidden").forEach(function(el) {
+        el.setAttribute("aria-hidden", "true");
+    });
+});

--- a/includes/js/custom.js
+++ b/includes/js/custom.js
@@ -385,6 +385,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
+// Set aria-hidden attribute to true for separator elements to improve accessibility
 document.addEventListener("DOMContentLoaded", function() {
     document.querySelectorAll("hr.separator-aria-hidden").forEach(function(el) {
         el.setAttribute("aria-hidden", "true");


### PR DESCRIPTION
This pull request includes a change to the `includes/js/custom.js` file to improve accessibility by setting the `aria-hidden` attribute on specific elements.

Accessibility improvement:

* [`includes/js/custom.js`](diffhunk://#diff-be9717e734e4058faac5990daab5dfea2817bcee49fab655bd50a42b47420182R387-R392): Added an event listener for `DOMContentLoaded` to set the `aria-hidden` attribute to `true` on all elements with the class `separator-aria-hidden`.