### PR TITLE
added: set border color for input fields and textareas for improved a11y

### DIFF
--- a/stylesheets/combined.css
+++ b/stylesheets/combined.css
@@ -1888,3 +1888,7 @@ ul.sep-list li::after {
 ul.sep-list li:last-child::after {
     content: "";
 }
+
+input[type="text"], input[type="password"], input[type="email"], textarea, select {
+	border-color: #757575;
+}

--- a/stylesheets/combined.css
+++ b/stylesheets/combined.css
@@ -57,7 +57,7 @@ input[type="text"],
 input[type="password"],
 input[type="email"],
 textarea,
-select{border:1px solid #ccc;padding:6px 4px;outline:none;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;font:13px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;color:#777;margin:0;max-width:100%;display:block;background:#fff;}
+select{border:1px solid #757575;padding:6px 4px;outline:none;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;font:13px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;color:#777;margin:0;max-width:100%;display:block;background:#fff;}
 select{padding:0 !important;}
 input[type="text"]:focus,
 input[type="password"]:focus,
@@ -1887,8 +1887,4 @@ ul.sep-list li::after {
 
 ul.sep-list li:last-child::after {
     content: "";
-}
-
-input[type="text"], input[type="password"], input[type="email"], textarea, select {
-	border-color: #757575;
 }


### PR DESCRIPTION
This pull request includes a small change to the `stylesheets/combined.css` file. The change adds a new rule to style the border color of various input elements.

* [`stylesheets/combined.css`](diffhunk://#diff-d663df70c65dd47bc8a2aef70c7b2dcaa199527f5e7075a5ace54b561888b966R1891-R1894): Added a rule to set the border color of `input[type="text"]`, `input[type="password"]`, `input[type="email"]`, `textarea`, and `select` elements to `#757575`.