### PR TITLE
updated: change background color of .menu-orng

### DIFF
--- a/stylesheets/combined.css
+++ b/stylesheets/combined.css
@@ -108,7 +108,7 @@ legend span{font-weight:normal;font-size:13px;color:#444;}
     }
 }
 .menu-dark{background:#787474;}
-.menu-orng{background:#ff6200;}
+.menu-orng{background:#1a3763;}
 .top-nav-holder{z-index:998;}
 @media screen and (min-width: 1024px) {
     .top-nav-holder{display: flex!important;justify-content: flex-end;}


### PR DESCRIPTION
This pull request updates the styling in `stylesheets/combined.css` to adjust the color scheme for better visual consistency.

Styling updates:

* Changed the background color of `.menu-orng` from `#ff6200` (orange) to `#1a3763` (dark blue) for improved aesthetic alignment.

Fixes: https://3.basecamp.com/3579237/buckets/32600659/card_tables/cards/8665043376