### PR TITLE
updated: changed input color

### DIFF
--- a/stylesheets/combined.css
+++ b/stylesheets/combined.css
@@ -57,7 +57,7 @@ input[type="text"],
 input[type="password"],
 input[type="email"],
 textarea,
-select{border:1px solid #757575;padding:6px 4px;outline:none;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;font:13px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;color:#777;margin:0;max-width:100%;display:block;background:#fff;}
+select{border:1px solid #757575;padding:6px 4px;outline:none;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;font:13px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;color:#555;margin:0;max-width:100%;display:block;background:#fff;}
 select{padding:0 !important;}
 input[type="text"]:focus,
 input[type="password"]:focus,


### PR DESCRIPTION
This pull request includes a minor change to the `stylesheets/combined.css` file. The change updates the text color for `select` elements from `#777` (gray) to `#555` (darker gray) for improved readability.

Fixes: https://3.basecamp.com/3579237/buckets/32600659/card_tables/cards/8564087736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the text color of all dropdown menus to a darker shade for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->