### PR TITLE
added: enhance accessibility for Otter Popup Modal with ARIA roles and focus trapping

### DIFF
--- a/includes/js/custom.js
+++ b/includes/js/custom.js
@@ -391,3 +391,74 @@ document.addEventListener("DOMContentLoaded", function() {
         el.setAttribute("aria-hidden", "true");
     });
 });
+
+// Otter Popup Modal Accessibility
+document.addEventListener('DOMContentLoaded', function () {
+	const modal = document.querySelector('.otter-popup__modal_content');
+	const overlay = document.querySelector('.otter-popup__modal_wrap_overlay');
+	const closeButton = document.querySelector('.otter-popup__modal_header button');
+
+	// Add ARIA roles and properties
+	const modalWrap = document.querySelector('.otter-popup__modal_wrap');
+	modal.setAttribute('role', 'dialog');
+	modal.setAttribute('aria-modal', 'true');
+	modal.setAttribute('aria-labelledby', 'wp-block-themeisle-blocks-advanced-heading-dc07cd14');
+
+	// Fix close button accessibility
+	closeButton.removeAttribute('aria-hidden');
+	closeButton.setAttribute('aria-label', 'Close modal');
+
+	// Trap focus inside modal
+	const focusableSelectors = [
+		'a[href]',
+		'button:not([disabled])',
+		'textarea:not([disabled])',
+		'input[type="text"]:not([disabled])',
+		'select:not([disabled])',
+		'[tabindex]:not([tabindex="-1"])'
+	];
+	let focusableElements = modal.querySelectorAll(focusableSelectors.join(','));
+	focusableElements = Array.prototype.slice.call(focusableElements);
+
+	let firstFocusable = focusableElements[0];
+	let lastFocusable = focusableElements[focusableElements.length - 1];
+
+	function trapFocus(e) {
+		if (e.key === 'Tab') {
+			if (e.shiftKey) {
+				// Shift + Tab
+				if (document.activeElement === firstFocusable) {
+					e.preventDefault();
+					lastFocusable.focus();
+				}
+			} else {
+				// Tab
+				if (document.activeElement === lastFocusable) {
+					e.preventDefault();
+					firstFocusable.focus();
+				}
+			}
+		}
+		if (e.key === 'Escape') {
+			closeModal();
+		}
+	}
+
+	function openModal() {
+		document.body.style.overflow = 'hidden';
+		firstFocusable.focus();
+		document.addEventListener('keydown', trapFocus);
+	}
+
+	function closeModal() {
+		document.body.style.overflow = '';
+		modalWrap.style.display = 'none';
+		document.removeEventListener('keydown', trapFocus);
+	}
+
+	closeButton.addEventListener('click', closeModal);
+	overlay.addEventListener('click', closeModal);
+
+	// Automatically open modal if needed
+	openModal();
+});

--- a/stylesheets/combined.css
+++ b/stylesheets/combined.css
@@ -1888,3 +1888,8 @@ ul.sep-list li::after {
 ul.sep-list li:last-child::after {
     content: "";
 }
+
+.otter-popup__modal_header button[aria-label="Close modal"]:focus {
+    outline: 2px solid #285598 !important;
+    outline-offset: 2px !important;
+}


### PR DESCRIPTION
This pull request enhances the accessibility and styling of the Otter Popup Modal. The changes include adding ARIA roles and properties for better screen reader support, implementing focus trapping within the modal, and improving the visual focus indicator for the close button.

### Accessibility Improvements:

* Added ARIA roles (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) to the modal in `includes/js/custom.js` for better screen reader compatibility.
* Enabled focus trapping inside the modal to ensure keyboard navigation remains within the modal while it is open.
* Fixed the close button's accessibility by removing `aria-hidden` and adding an `aria-label` attribute for screen readers.

### Styling Enhancements:

* Added a focus outline style for the close button in `stylesheets/combined.css` to improve visibility when navigating via keyboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved accessibility for the Otter Popup Modal, including ARIA roles, keyboard navigation, and focus management.
- **Style**
	- Enhanced focus indicator styling for the modal’s close button to improve visibility during keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->