### PR TITLE
Remove: sidebar inclusion from 404 error page

### DIFF
--- a/404.php
+++ b/404.php
@@ -32,7 +32,6 @@
 
 						</div><!-- #main -->
 					</main><!-- two-thirds -->
-	                <?php get_sidebar(); ?>
 				</div><!-- #content -->
 			</div><!-- #primary -->
 	    </div>


### PR DESCRIPTION
This pull request makes a minor change to the `404.php` file by removing the call to display the sidebar on the 404 error page.